### PR TITLE
Fix bug of sh()

### DIFF
--- a/oh-my-tuna.py
+++ b/oh-my-tuna.py
@@ -60,7 +60,7 @@ def sh(command):
             print('$ %s' % command)
         if isinstance(command, str):
             command = command.split()
-        return subprocess.check_output(command, stderr=subprocess.STDOUT).decode('utf-8').rstrip()
+        return subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8').rstrip()
     except Exception as e:
         return None
 

--- a/oh-my-tuna.py
+++ b/oh-my-tuna.py
@@ -22,6 +22,7 @@ import errno
 import argparse
 import re
 import platform
+import shlex
 from contextlib import contextmanager
 
 try:
@@ -59,7 +60,7 @@ def sh(command):
         if verbose:
             print('$ %s' % command)
         if isinstance(command, str):
-            command = command.split()
+            command = shlex.split(command)
         return subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8').rstrip()
     except Exception as e:
         return None


### PR DESCRIPTION
应给 ``subprocess.check_output()`` 加一个 ``shell=True``，解决 Windows 下对 CTAN 是否存在的判定错误。