### PR TITLE
Fix bug of _get_mirror_suffix() (raising TypeError on windows)

### DIFF
--- a/oh-my-tuna.py
+++ b/oh-my-tuna.py
@@ -619,7 +619,7 @@ class Debian(Base):
 def _get_mirror_suffix():
     uname = sh('uname -m')
     no_suffix_list = ['i386', 'i586', 'i686', 'x86_64', 'amd64']
-    if any(map(lambda x: x in uname, no_suffix_list)):
+    if uname == None or any(map(lambda x: x in uname, no_suffix_list)):
         return ''
     else:
         return '-ports'


### PR DESCRIPTION
Function _get_mirror_suffix() runs "uname -m" and checks if it contains any of ['i386', 'i586', 'i686', 'x86_64', 'amd64'], but on windows the shell returns None which is not iterable and lead to TypeError.