### PR TITLE
Add uv package manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Coverage
  - TeX Live (by tlmgr)
  - CentOS
  - AOSC OS
+ - UV
  
 TODO
 ========================

--- a/oh-my-tuna.py
+++ b/oh-my-tuna.py
@@ -736,8 +736,69 @@ class AOSCOS(Base):
             return False
         return True
 
+class UV(Base):
+    mirror_url = 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/'
 
-MODULES = [ArchLinux, Homebrew, CTAN, Pypi, Anaconda, Debian, Ubuntu, CentOS, AOSCOS]
+    @staticmethod
+    def config_files():
+        return ('~/.config/uv/uv.toml', '/etc/uv/uv.toml')
+
+    @staticmethod
+    def name():
+        return "uv"
+
+    @staticmethod
+    def is_applicable():
+        # Works both in global mode and local mode
+        return sh('uv --version') is not None
+
+    @staticmethod
+    def is_online():
+        config_files = UV.config_files()
+        for conf_file in config_files:
+            expanded_path = os.path.expanduser(conf_file)
+            if not os.path.exists(expanded_path):
+                continue
+            try:
+                with open(expanded_path, 'r') as f:
+                    content = f.read()
+                    if 'url = "' + UV.mirror_url + '"' in content and 'default = true' in content:
+                        return True
+            except Exception:
+                continue
+        return False
+
+    @staticmethod
+    def up():
+        global is_global
+        config_file = os.path.expanduser(UV.config_files()[1] if is_global else UV.config_files()[0])
+        
+        config_content = '''[[index]]
+url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/"
+default = true
+'''
+        
+        if not os.path.isdir(os.path.dirname(config_file)):
+            mkdir_p(os.path.dirname(config_file))
+        
+        with open(config_file, 'w') as f:
+            f.write(config_content)
+        return True
+
+    @staticmethod
+    def down():
+        config_files = UV.config_files()
+        for conf_file in config_files:
+            expanded_path = os.path.expanduser(conf_file)
+            if os.path.exists(expanded_path):
+                try:
+                    os.remove(expanded_path)
+                except Exception:
+                    pass
+        return True
+
+
+MODULES = [ArchLinux, Homebrew, CTAN, Pypi, Anaconda, Debian, Ubuntu, CentOS, AOSCOS, UV]
 
 
 def main():
@@ -814,3 +875,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Add uv package manager support

### Summary
This PR adds support for the `uv` Python package manager to oh-my-tuna, enabling automatic configuration of TUNA PyPI mirrors for uv users.

### What's Added
- **New UV class**: Implements the `Base` interface to support uv package manager
- **Configuration management**: Automatically configures uv to use TUNA PyPI mirror (`https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/`)
- **Cross-platform support**: Works with both user-level (`~/.config/uv/uv.toml`) and system-level (`/etc/uv/uv.toml`) configurations
- **Global/local mode support**: Respects the `-g/--global` flag for system-wide or user-specific configurations

### Key Features
- **Detection**: Automatically detects if `uv` is installed via `uv --version`
- **Status checking**: Verifies if TUNA mirror is already configured
- **Activation**: Creates proper TOML configuration with TUNA mirror as default index
- **Deactivation**: Cleanly removes configuration files when disabling
- **Directory creation**: Automatically creates config directories if they don't exist

### Configuration Format
The implementation generates a clean TOML configuration:
```toml
[[index]]
url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/"
default = true
```

### Testing
- Works in both global (`-g`) and local modes
- Properly handles missing configuration directories
- Safe file operations with appropriate error handling
- Integrates seamlessly with existing oh-my-tuna workflow

### Usage
```bash
# Activate uv mirror (user-level)
python oh-my-tuna.py up

# Activate uv mirror (system-level)  
python oh-my-tuna.py up -g

# Check status
python oh-my-tuna.py status

# Deactivate
python oh-my-tuna.py down
```

This enhancement brings uv support in line with other package managers already supported by oh-my-tuna, providing a consistent experience for Python developers using this modern package manager.
